### PR TITLE
Run liquid benchmarks alongside ruby benchmarks instead of having separate liquid benchmarks

### DIFF
--- a/ruby/ruby_releases/ruby_benchmarks/runner
+++ b/ruby/ruby_releases/ruby_benchmarks/runner
@@ -48,7 +48,6 @@ fi
 
 if [ "$LIQUID_BENCHMARK" = true ]; then
   echo "Running liquid benchmarks with Ruby $RUBY_VERSION"
-  gem update bundler
   gem install bundler --no-ri --no-rdoc
   cd /ruby-bench-suite/liquid_benchmarks/liquid
   bundle install --without test

--- a/ruby/ruby_releases/ruby_benchmarks/runner
+++ b/ruby/ruby_releases/ruby_benchmarks/runner
@@ -45,3 +45,14 @@ if [ "$OPTCARROT_BENCHMARK" = true ]; then
 else
   echo "Skipping optcarrot benchmarks"
 fi
+
+if [ "$LIQUID_BENCHMARK" = true ]; then
+  echo "Running liquid benchmarks with Ruby $RUBY_VERSION"
+  gem update bundler
+  gem install bundler --no-ri --no-rdoc
+  cd /ruby-bench-suite/liquid_benchmarks/liquid
+  bundle install --without test
+  bundle exec ruby /ruby-bench-suite/liquid_benchmarks/driver.rb
+else
+  echo "Skipping liquid benchmarks"
+fi

--- a/ruby/ruby_trunk/ruby_benchmarks/runner
+++ b/ruby/ruby_trunk/ruby_benchmarks/runner
@@ -57,7 +57,6 @@ fi
 
 if [ "$LIQUID_BENCHMARK" = true ]; then
   echo "Running liquid benchmarks with Ruby $RUBY_VERSION"
-  gem update bundler
   gem install bundler --no-ri --no-rdoc
   cd /ruby-bench-suite/liquid_benchmarks/liquid
   bundle install --without test

--- a/ruby/ruby_trunk/ruby_benchmarks/runner
+++ b/ruby/ruby_trunk/ruby_benchmarks/runner
@@ -54,3 +54,14 @@ if [ "$OPTCARROT_BENCHMARK" = true ]; then
 else
   echo "Skipping optcarrot benchmarks"
 fi
+
+if [ "$LIQUID_BENCHMARK" = true ]; then
+  echo "Running liquid benchmarks with Ruby $RUBY_VERSION"
+  gem update bundler
+  gem install bundler --no-ri --no-rdoc
+  cd /ruby-bench-suite/liquid_benchmarks/liquid
+  bundle install --without test
+  bundle exec ruby /ruby-bench-suite/liquid_benchmarks/driver.rb
+else
+  echo "Skipping liquid benchmarks"
+fi


### PR DESCRIPTION
Instead of adding separate liquid directories under `ruby_trunk` and `ruby_releases`, this would run the liquid benchmarks when other ruby benchmarks are run.